### PR TITLE
Refactor: Remove SQLite and use PostgreSQL exclusively

### DIFF
--- a/axum_app/Cargo.toml
+++ b/axum_app/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 axum = "0.7"
 tokio = { version = "1", features = ["full"] }
-sqlx = { version = "0.7.4", features = [ "runtime-tokio-rustls", "sqlite", "postgres" ] } # Reverted to 0.7.4
+sqlx = { version = "0.7.4", features = [ "runtime-tokio-rustls", "postgres" ] } # Reverted to 0.7.4
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = "1.0" # Added anyhow

--- a/axum_app/src/lib.rs
+++ b/axum_app/src/lib.rs
@@ -3,7 +3,7 @@ use axum::{
     extract::State, http::StatusCode, routing::{get, post}, Json, Router,
 };
 use serde::{Deserialize, Serialize};
-use sqlx::{migrate::MigrateDatabase, Pool, Database, Sqlite, SqlitePool, PgPool, AnyKind};
+use sqlx::{migrate::MigrateDatabase, Pool, Database, PgPool, AnyKind};
 use std::env;
 use std::net::SocketAddr;
 use anyhow::Result;
@@ -25,55 +25,33 @@ pub struct Message {
     pub text: String,
 }
 
-// Generic function to create the database schema.
-async fn create_schema<DB: Database>(pool: &Pool<DB>, db_type: &str) -> Result<(), sqlx::Error> {
-    let schema_sql = if db_type == "postgres" {
-        "CREATE TABLE IF NOT EXISTS messages (id SERIAL PRIMARY KEY, text TEXT NOT NULL);"
-    } else { // sqlite
-        "CREATE TABLE IF NOT EXISTS messages (id INTEGER PRIMARY KEY AUTOINCREMENT, text TEXT NOT NULL);"
-    };
+// Function to create the database schema for PostgreSQL.
+async fn create_schema(pool: &PgPool) -> Result<(), sqlx::Error> {
+    let schema_sql = "CREATE TABLE IF NOT EXISTS messages (id SERIAL PRIMARY KEY, text TEXT NOT NULL);";
     sqlx::query(schema_sql).execute(pool).await?;
-    println!("'messages' table checked/created successfully for {} using schema: {}", db_type, schema_sql);
+    println!("'messages' table checked/created successfully for PostgreSQL using schema: {}", schema_sql);
     Ok(())
 }
 
-// Generic function to run the application.
-pub async fn run_app<DB: Database + 'static>(
-    pool: Pool<DB>,
+// Function to run the application with PostgreSQL.
+pub async fn run_app(
+    pool: PgPool,
     listener: tokio::net::TcpListener,
-    db_type: &'static str, // Pass db_type for schema creation and potentially other logic
 ) -> Result<()>
-where
-    for<'a> &'a Pool<DB>: sqlx::Executor<'a, Database = DB>,
 {
     // Schema creation
-    create_schema(&pool, db_type).await.expect("Failed to create schema");
+    create_schema(&pool).await.expect("Failed to create schema");
 
     let app = Router::new()
         .route("/", get(root_handler))
         .route("/json", get(json_handler)) // json_handler is simple, no DB interaction
-        .route("/messages", post(create_message_handler::<DB>))
-        .route("/messages", get(list_messages_handler::<DB>))
-        .with_state(pool); // Pass the generic pool
+        .route("/messages", post(create_message_handler::<sqlx::Postgres>))
+        .route("/messages", get(list_messages_handler::<sqlx::Postgres>))
+        .with_state(pool); // Pass the PgPool
 
     println!("Listening on http://{}", listener.local_addr()?);
     axum::serve(listener, app).await?;
     Ok(())
-}
-
-// Function to setup and run the application with SQLite.
-pub async fn run_app_sqlite() -> Result<()> {
-    let db_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set for main application");
-    if !Sqlite::database_exists(&db_url).await.unwrap_or(false) {
-        println!("Creating database {}", db_url);
-        Sqlite::create_database(&db_url).await?;
-    } else {
-        println!("Database {} already exists.", db_url);
-    }
-    let pool = SqlitePool::connect(&db_url).await?;
-    let addr = SocketAddr::from(([0, 0, 0, 0], 3000));
-    let listener = tokio::net::TcpListener::bind(addr).await?;
-    run_app(pool, listener, "sqlite").await
 }
 
 // Handler for the root path (`/`).
@@ -91,19 +69,15 @@ async fn json_handler() -> Json<Message> {
     })
 }
 
-// Generic handler for creating a new message (POST `/messages`).
-async fn create_message_handler<DB: Database>(
+// Handler for creating a new message (POST `/messages`) for PostgreSQL.
+async fn create_message_handler<DB: Database>( // Still generic for now, but used with PgPool
     State(pool): State<Pool<DB>>,      // Extract the database pool from application state.
     Json(payload): Json<CreateMessage>, // Deserialize the request body into `CreateMessage`.
 ) -> Result<StatusCode, (StatusCode, String)>
 where
-    for<'c> &'c Pool<DB>: sqlx::Executor<'c, Database = DB>,
+    for<'c> &'c Pool<DB>: sqlx::Executor<'c, Database = DB>, // This bound is fine
 {
-    // Determine placeholder style based on database kind
-    let query_str = match pool.any_kind() {
-        AnyKind::Postgres => "INSERT INTO messages (text) VALUES ($1)",
-        _ => "INSERT INTO messages (text) VALUES (?1)", // Default to SQLite style
-    };
+    let query_str = "INSERT INTO messages (text) VALUES ($1)"; // PostgreSQL specific query
 
     sqlx::query(query_str)
         .bind(payload.text)
@@ -118,12 +92,12 @@ where
     Ok(StatusCode::CREATED)
 }
 
-// Generic handler for listing all messages (GET `/messages`).
-async fn list_messages_handler<DB: Database>(
+// Handler for listing all messages (GET `/messages`) for PostgreSQL.
+async fn list_messages_handler<DB: Database>( // Still generic for now, but used with PgPool
     State(pool): State<Pool<DB>>, // Extract the database pool from application state.
 ) -> Result<Json<Vec<Message>>, (StatusCode, String)>
 where
-    for<'c> &'c Pool<DB>: sqlx::Executor<'c, Database = DB>,
+    for<'c> &'c Pool<DB>: sqlx::Executor<'c, Database = DB>, // This bound is fine
 {
     // The SQL query "SELECT id, text FROM messages ORDER BY id" is compatible with both SQLite and Postgres.
     // Using sqlx::query_as (the function, not the macro) for better generic type handling.

--- a/axum_app/src/main.rs
+++ b/axum_app/src/main.rs
@@ -1,8 +1,25 @@
 // axum_app/src/main.rs
-use axum_app::run_app_sqlite;
+use axum_app::run_app; // Updated import
+use sqlx::PgPool;
+use std::env;
+use std::net::SocketAddr;
+use tokio::net::TcpListener;
 use anyhow::Result;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    run_app_sqlite().await
+    // DATABASE_URL will now be for PostgreSQL
+    let database_url = env::var("DATABASE_URL")
+        .expect("DATABASE_URL must be set and point to a PostgreSQL instance");
+    
+    // Connect to PostgreSQL
+    let pool = PgPool::connect(&database_url).await?;
+    
+    // Set up listener
+    let addr = SocketAddr::from(([0, 0, 0, 0], 3000)); // Or make port configurable
+    let listener = TcpListener::bind(addr).await?;
+    
+    // Run the application
+    println!("Starting server with PostgreSQL backend..."); // Optional: some indication
+    run_app(pool, listener).await
 }


### PR DESCRIPTION
This commit modifies the application to remove all SQLite-specific code and use PostgreSQL as the sole database backend.

Changes include:
- Removed "sqlite" feature from the sqlx dependency in Cargo.toml.
- Updated lib.rs to remove SQLite imports, SQLite-specific functions (run_app_sqlite), and conditional logic for SQLite in database operations (create_schema, create_message_handler).
- The run_app function now specifically uses PgPool.
- Updated main.rs to initialize a PgPool and call the updated run_app function.

Note on testing:
The existing integration tests are designed for PostgreSQL. However, I was unable to run the tests due to
Rust compiler version (1.75.0) incompatibilities with required crate versions and subsequent dependency resolution conflicts. Therefore, these changes could not be verified by the automated test suite in the provided environment.